### PR TITLE
Delay jurisdiction processing by 5s

### DIFF
--- a/State/JurisdictionManager.cs
+++ b/State/JurisdictionManager.cs
@@ -7,8 +7,13 @@ namespace AtopPlugin.State;
 
 public static class JurisdictionManager
 {
+    private const int FdrUpdateDelay = 5000;
+
     public static async Task HandleFdrUpdate(FDP2.FDR fdr)
     {
+        // Delay the processing so that vatSys can sync EST state
+        await Task.Delay(FdrUpdateDelay);
+
         if (!fdr.ESTed && MMI.IsMySectorConcerned(fdr)) MMI.EstFDR(fdr);
 
         var isInControlledSector = await IsInControlledSector(fdr.GetLocation(), fdr.PRL);

--- a/Version.cs
+++ b/Version.cs
@@ -4,8 +4,8 @@ public static class Version
 {
     private const string VersionPrefix = "Version ";
     private const int AiracVersion = 2403;
-    private const int MajorVersion = 2;
-    private const int MinorVersion = 1;
+    private const int MajorVersion = 3;
+    private const int MinorVersion = 0;
 
     public static string GetVersionString()
     {


### PR DESCRIPTION
This allows vatSys to catch up on EST processing and avoids multiple controllers' EST messages conflicting with each other