### PR TITLE
Fix flight plan editor switching to unrelated FDR updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -310,8 +310,11 @@ function handleAltitudeUpdate(data) {
 }
 
 function handleFlightPlanUpdate(data) {
+    // Only refresh if this is the flight plan already open
+    if (!currentFDR || currentFDR.Callsign !== data.Callsign) return;
+
     currentFDR = data;
-    
+
     // Update status header
     setTextContent('fp-callsign-display', data.Callsign || '-------');
     setTextContent('fp-dep-display', data.DepAirport || '----');


### PR DESCRIPTION
handleFlightPlanUpdate always overwrites the FPL editor with any incoming FlightPlanUpdate message, causing the editor to randomly jump to a different flight plan whenever any FDR updates.

Only refresh the form if the incoming callsign matches the flight plan already open. An empty editor stays empty until the user explicitly searches or selects a flight plan.